### PR TITLE
Default for wiki prompt

### DIFF
--- a/lua/kiwi/utils.lua
+++ b/lua/kiwi/utils.lua
@@ -134,13 +134,9 @@ utils.choose_wiki = function (folders, total)
   { prompt = prompt_text },
   function(input)
     input = tonumber(input)
-    if type(input) ~= "number" then
-      print("\nInvalid input")
-      return
-    end
-    if total < input then
+    if type(input) ~= "number" or total < (input) then
       print("\nInvalid index")
-      return
+      input = 1
     end
     path = folders[input].path
   end


### PR DESCRIPTION
The prompt for opening a wiki states that it defaults to the first entry. Instead it currently defaults to the users home directory regardless of the first entry destination folder. This pr fixes such.
