### PR TITLE
Use (sub)directory structure when creating files

### DIFF
--- a/lua/kiwi/utils.lua
+++ b/lua/kiwi/utils.lua
@@ -40,6 +40,12 @@ utils.get_wiki_path = function()
   return default_dir
 end
 
+-- Get the relative path to the current buffer from the Wiki folder
+utils.get_relative_path =  function (config)
+  local relative_path = vim.fs.dirname(vim.fn.expand('%:p'))
+  return relative_path:gsub(config.path, "")
+end
+
 -- Create wiki folder
 utils.ensure_directories = function(config)
   if (config.folders ~= nil) then

--- a/lua/kiwi/wiki.lua
+++ b/lua/kiwi/wiki.lua
@@ -32,12 +32,10 @@ M.create_or_open_wiki_file = function()
   local name = line[1]:sub(selection_start[3], selection_end[3])
   local filename = name:gsub(" ", "_"):gsub("\\", "") .. ".md"
   local new_mkdn = "[" .. name .. "]"
-  local relativePath = vim.fs.dirname(vim.fn.expand('%:p')) .. sep
-  relativePath =  relativePath:gsub(config.path .. sep, "")
-  new_mkdn = new_mkdn .. "(." .. sep .. relativePath .. filename .. ")"
+  new_mkdn = new_mkdn .. "(./" .. filename .. ")"
   local newline = line[1]:sub(0, selection_start[3] - 1) .. new_mkdn .. line[1]:sub(selection_end[3] + 1, string.len(line[1]))
   vim.api.nvim_set_current_line(newline)
-  local buffer_number = vim.fn.bufnr(config.path .. sep .. relativePath .. filename, true)
+  local buffer_number = vim.fn.bufnr(config.path .. utils.get_relative_path(config) .. sep .. filename, true)
   vim.api.nvim_win_set_buf(0, buffer_number)
   local opts = { noremap = true, silent = true, nowait = true }
   vim.api.nvim_buf_set_keymap(buffer_number, "v", "<CR>", ":'<,'>lua require(\"kiwi\").create_or_open_wiki_file()<CR>", opts)
@@ -52,7 +50,7 @@ M.open_link = function()
   local filename = utils.is_link(cursor, line)
   if (filename ~= nil and filename:len() > 1) then
     if (filename:sub(1, 2) == "./") then
-      filename = config.path .. filename:sub(2, -1)
+      filename = config.path .. utils.get_relative_path(config) .. filename:sub(2, -1)
     end
     local buffer_number = vim.fn.bufnr(filename, true)
     if buffer_number ~= -1 then

--- a/lua/kiwi/wiki.lua
+++ b/lua/kiwi/wiki.lua
@@ -32,10 +32,12 @@ M.create_or_open_wiki_file = function()
   local name = line[1]:sub(selection_start[3], selection_end[3])
   local filename = name:gsub(" ", "_"):gsub("\\", "") .. ".md"
   local new_mkdn = "[" .. name .. "]"
-  new_mkdn = new_mkdn .. "(./" .. filename .. ")"
+  local relativePath = vim.fs.dirname(vim.fn.expand('%:p')) .. sep
+  relativePath =  relativePath:gsub(config.path .. sep, "")
+  new_mkdn = new_mkdn .. "(." .. sep .. relativePath .. filename .. ")"
   local newline = line[1]:sub(0, selection_start[3] - 1) .. new_mkdn .. line[1]:sub(selection_end[3] + 1, string.len(line[1]))
   vim.api.nvim_set_current_line(newline)
-  local buffer_number = vim.fn.bufnr(config.path .. sep .. filename, true)
+  local buffer_number = vim.fn.bufnr(config.path .. sep .. relativePath .. filename, true)
   vim.api.nvim_win_set_buf(0, buffer_number)
   local opts = { noremap = true, silent = true, nowait = true }
   vim.api.nvim_buf_set_keymap(buffer_number, "v", "<CR>", ":'<,'>lua require(\"kiwi\").create_or_open_wiki_file()<CR>", opts)


### PR DESCRIPTION
As is described in issue #10 kiwi will always create new MD files in the root directory of the wiki, even if a wiki file is already within a subdirectory.
This PR changes the behavior so that kiwi will respect the subdirectory structure. In particular, it utilizes the second approach mentioned in the issue above, by generating a relative path from the wiki-directory and then also opening the buffer there.

Example:
Creating a new link inside `wiki/sub/file.md` will create this link: `[newfile](./sub/newfile)`.
The buffer of the new file `Newfile.md` will then be inside the sub directory too.
That is, if the buffer gets written, it is written to: `wiki/sub/newfile`

I've chosen the second approach for implementation, that is, having the relative path in the markdown link since this makes the links more intuitive and transparent when viewing the wiki-directory as a "root directory". If one explicitly sets a link to be `(./file)` within another file that is in a subdirectory, that link will reference back to the root-directory of the wiki.
 
 closes #10 
