### PR TITLE
Fix non-recursive directory creation

### DIFF
--- a/lua/kiwi/utils.lua
+++ b/lua/kiwi/utils.lua
@@ -27,7 +27,7 @@ end
 local create_dirs = function (wiki_path)
   local path = Path:new(wiki_path)
   if not path:exists() then
-    path:mkdir()
+    path:mkdir({parents = true})
   end
 end
 


### PR DESCRIPTION
When specifying a wiki path of: `$HOME/wiki/personal`, with directory `$HOME/wiki` being non-existent, I get the following error message:

```

Failed to run `config` for kiwi.nvim

....local/share/nvim/lazy/plenary.nvim/lua/plenary/path.lua:511: FileNotFoundError

# stacktrace:
  - /plenary.nvim/lua/plenary/path.lua:511 _in_ **mkdir**
  - /kiwi.nvim/lua/kiwi/utils.lua:30 _in_ **create_dirs**
  - /kiwi.nvim/lua/kiwi/utils.lua:53 _in_ **ensure_directories**
  - /kiwi.nvim/lua/kiwi/utils.lua:14 _in_ **setup**
  - /kiwi.nvim/lua/kiwi/init.lua:13 _in_ **setup**
```

It appears that on https://github.com/serenevoid/kiwi.nvim/blob/master/lua/kiwi/utils.lua#L30, we should be using `path:mkdir({parents = true})`.

This pull request fixes that.  I've done a little bit of testing, creating the directory tree, requiring both recursive mkdir and non-recursive, and thing seem to be working just fine with this fix.