### PR TITLE
fix: detects if props.path is absolute or relative path

### DIFF
--- a/lua/kiwi/utils.lua
+++ b/lua/kiwi/utils.lua
@@ -85,7 +85,12 @@ utils.choose_wiki = function(folders)
   }, function(choice)
     for _, props in pairs(folders) do
       if props.name == choice then
-        path = vim.fs.joinpath(vim.loop.os_homedir(), props.path)
+        -- Check if is a path or just a name
+        if vim.loop.fs_realpath(props.path) then
+          path = props.path
+        else
+          path = vim.fs.joinpath(vim.loop.os_homedir(), props.path)
+        end
       end
     end
   end)


### PR DESCRIPTION
I don't keep my notes in the home dir and use absolute path. 
Previous code generated error because it joined 2 absolute paths.

(cherry picked from commit 3303bee621aa220e399f9282e8dec065f102dfad)