### PR TITLE
Fix creating a file in a current directory instead of `config.path`

### DIFF
--- a/lua/kiwi/utils.lua
+++ b/lua/kiwi/utils.lua
@@ -55,7 +55,7 @@ utils.is_link = function(cursor, line)
     if not match_start then break end
     start_pos = match_end + 1 -- Move past the current match
     file = utils._is_cursor_on_file(cursor, file, match_start, match_end)
-    if file then return file end
+    if file then return "./" .. file end
   end
 
   return nil


### PR DESCRIPTION
As described in the issue https://github.com/serenevoid/kiwi.nvim/issues/39, when entering in a file like kiwi tried to create a file in a current directory. This PR fixes it. 
