### PR TITLE
feat: support configurable index file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ For [Lazy](https://github.com/folke/lazy.nvim) users,
         },
         {
             name = "personal",
-            path = "personal-wiki"
+            path = "personal-wiki",
+            index_file = "README.md" -- Optional, defaults to "index.md"
         }
     },
     keys = {
@@ -146,7 +147,8 @@ require('kiwi').setup({
     },
     {
         name = "personal",
-        path = "personal-wiki"
+        path = "personal-wiki",
+        index_file = "README.md" -- Optional, defaults to "index.md"
     }
 })
 -- Note: The path will be created in user home directory

--- a/lua/kiwi/wiki.lua
+++ b/lua/kiwi/wiki.lua
@@ -10,6 +10,7 @@ M.open_wiki_index = function(name)
       for _, v in pairs(config.folders) do
         if v.name == name then
           config.path = v.path
+          config.index_file = v.index_file or "index.md"
         end
       end
     else
@@ -18,7 +19,7 @@ M.open_wiki_index = function(name)
   else
     require("kiwi").setup()
   end
-  local wiki_index_path = vim.fs.joinpath(config.path, "index.md")
+  local wiki_index_path = vim.fs.joinpath(config.path, config.index_file)
   local buffer_number = vim.fn.bufnr(wiki_index_path, true)
   vim.api.nvim_win_set_buf(0, buffer_number)
   local opts = { noremap = true, silent = true, nowait = true }


### PR DESCRIPTION
# Summary
- Add support for configurable index file names
- Update documentation with examples showing how to use the new `index_file` option

# Motivation
When storing wiki notes on GitHub, only `README.md` files are automatically rendered on the repository's home page.
This feature allows users to set their wiki index file to `README.md` (or any other filename) to take advantage of GitHub's automatic rendering while maintaining flexibility for different use cases.